### PR TITLE
Fixed the test spec to grab the latest Ansible in stream

### DIFF
--- a/openshift-ansible.spec
+++ b/openshift-ansible.spec
@@ -61,7 +61,7 @@ cp -rp test %{buildroot}%{_datadir}/ansible/%{name}/
 %package test
 Summary:       Openshift and Atomic Enterprise Ansible Test Playbooks
 Requires:      %{name} = %{version}-%{release}
-Requires:      ansible = 2.9.5
+Requires:      ansible >= 2.9.5
 Requires:      openssh-clients
 BuildArch:     noarch
 


### PR DESCRIPTION
When we build our RPMs, we end up failing TPS tests because the Ansible version is locked to a version, but we don't lock our deployment streams to a single version of Ansible.

This would have to be cherry-picked back into the corresponding branches down to 4.2 for Multi-Arch support.